### PR TITLE
switch tld level to 1.1

### DIFF
--- a/src/main/resources/META-INF/dasein.tld
+++ b/src/main/resources/META-INF/dasein.tld
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
-<taglib xmlns="http://java.sun.com/xml/ns/j2ee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee/web-jsptaglibrary_2_0.xsd"
-    version="2.0">
+<!DOCTYPE taglib PUBLIC "-//Sun Microsystems, Inc.//DTD JSP Tag Library 1.1//EN" "http://java.sun.com/j2ee/dtds/web-jsptaglibrary_1_1.dtd">
+<taglib>
 
   <tlibversion>1.0</tlibversion>
   <jspversion>1.1</jspversion>


### PR DESCRIPTION
The dasein.tld file references the http://java.sun.com/xml/ns/j2ee/web-jsptaglibrary_2_0.xsd schema file, but on examining the TLD file you will see that the contents are still for 1.1. For example, the TLD 1.x version has a <tlibversion> tag, while version 2.x has a <tlib-version> tag. Having the wrong schema level identified can cause deployment issues in app servers that validate the schema.
